### PR TITLE
MOD-C-2-CPP: Compatibility fixed for NEURON 9.0, 8.2 and 8.1 (#1)

### DIFF
--- a/burststim2.mod
+++ b/burststim2.mod
@@ -70,8 +70,13 @@ FUNCTION invl(mean (ms)) (ms) {
 	}
 }
 VERBATIM
+#ifndef NRN_VERSION_GTEQ_8_2_0
 double nrn_random_pick(void* r);
 void* nrn_random_arg(int argpos);
+#define RANDCAST
+#else
+#define RANDCAST (Rand*)
+#endif
 ENDVERBATIM
 
 FUNCTION erand() {
@@ -82,7 +87,7 @@ VERBATIM
 		: each instance. However, the corresponding hoc Random
 		: distribution MUST be set to Random.negexp(1)
 		*/
-		_lerand = nrn_random_pick(_p_donotuse);
+		_lerand = nrn_random_pick(RANDCAST _p_donotuse);
 	}else{
 ENDVERBATIM
 		: the old standby. Cannot use if reproducible parallel sim

--- a/ichan2.mod
+++ b/ichan2.mod
@@ -91,7 +91,7 @@ INITIAL {
       ns = nsinf
 	
 	VERBATIM
-	return 0;
+	return;
 	ENDVERBATIM
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -59,3 +59,8 @@ but the model still works as described.
 To reproduce the published results, comment out the "rates(v)" line in the
 DERIVATIVE block of IA.mod.
 **********************************
+
+Changelog
+---------
+2022-05: Updated MOD files to contain valid C++ and be compatible with
+         the upcoming versions 8.2 and 9.0 of NEURON.

--- a/regn_stim.mod
+++ b/regn_stim.mod
@@ -82,8 +82,13 @@ FUNCTION invl(mean (ms)) (ms) {
 	tspike = tspike + mean
 }
 VERBATIM
+#ifndef NRN_VERSION_GTEQ_8_2_0
 double nrn_random_pick(void* r);
 void* nrn_random_arg(int argpos);
+#define RANDCAST
+#else
+#define RANDCAST (Rand*)
+#endif
 ENDVERBATIM
 
 FUNCTION erand() {
@@ -94,7 +99,7 @@ VERBATIM
 		: each instance. However, the corresponding hoc Random
 		: distribution MUST be set to Random.normal(0, 1) (BPG)
 		*/
-		_lerand = nrn_random_pick(_p_donotuse);
+		_lerand = nrn_random_pick(RANDCAST _p_donotuse);
 	}else{
 ENDVERBATIM
 		: the old standby. Cannot use if reproducible parallel sim


### PR DESCRIPTION
* MOD-C-2-CPP: Compatibility fixed for NEURON 9.0, 8.2 and 8.1

* fix for nrnivmodl

* Cleanup for merge.

Co-authored-by: Olli Lupton <oliver.lupton@epfl.ch>